### PR TITLE
Harden GitHub workflow; await template copies and add Palguard support

### DIFF
--- a/.github/workflows/check-plugin-updates.yml
+++ b/.github/workflows/check-plugin-updates.yml
@@ -6,6 +6,14 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch: # 允许手动触发
 
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: check-plugin-updates
+  cancel-in-progress: true
+
 jobs:
   check-updates:
     runs-on: ubuntu-latest
@@ -21,9 +29,20 @@ jobs:
 
       - name: Check UE4SS latest version
         id: ue4ss
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          LATEST=$(curl -s https://api.github.com/repos/UE4SS-RE/RE-UE4SS/releases/latest | jq -r '.tag_name')
-          echo "latest=$LATEST" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          RESPONSE=$(curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/UE4SS-RE/RE-UE4SS/releases/latest)
+          LATEST=$(echo "$RESPONSE" | jq -r '.tag_name')
+          if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
+            echo "无法解析 UE4SS 最新版本" >&2
+            exit 1
+          fi
+          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
           echo "UE4SS 最新版本: $LATEST"
 
       - name: Check PalGuard latest version

--- a/package.json
+++ b/package.json
@@ -262,15 +262,15 @@
   "collective": {
     "url": "https://opencollective.com/electron-react-boilerplate-594"
   },
-  "devEngines": {
-    "node": ">=14.x",
-    "npm": ">=7.x"
-  },
   "electronmon": {
     "patterns": [
       "!**/**",
       "src/main/**"
     ],
     "logLevel": "quiet"
+  },
+  "engines": {
+    "node": ">=14.x",
+    "npm": ">=7.x"
   }
 }

--- a/src/main/ipcs/server/exec/execStartServer.tsx
+++ b/src/main/ipcs/server/exec/execStartServer.tsx
@@ -9,6 +9,7 @@ import fs from 'fs/promises';
 import fsc from 'fs';
 import getServerInfoByServerId from '../../../services/serverInstanceSettings/getServerInfoByServerId';
 import loadUE4SSTemplate from '../../../services/templates/loadUE4SSTemplate';
+import loadPalguardTemplate from '../../../services/templates/loadPalguardTemplate';
 import sleep from '../../../../utils/sleep';
 import pidusage from 'pidusage';
 import osu from 'node-os-utils';
@@ -54,7 +55,7 @@ ipcMain.on(
     else {
       // eslint-disable-next-line no-lonely-if
       if (ue4ssEnabled) {
-        loadUE4SSTemplate(path.join(serverPath, 'Pal/Binaries/Win64'));
+        await loadUE4SSTemplate(path.join(serverPath, 'Pal/Binaries/Win64'));
       }
     }
 
@@ -87,7 +88,7 @@ ipcMain.on(
     else {
       // eslint-disable-next-line no-lonely-if
       if (palguardEnabled) {
-        loadUE4SSTemplate(path.join(serverPath, 'Pal/Binaries/Win64'));
+        await loadPalguardTemplate(path.join(serverPath, 'Pal/Binaries/Win64'));
       }
     }
 

--- a/src/main/services/templates/loadPalguardTemplate.ts
+++ b/src/main/services/templates/loadPalguardTemplate.ts
@@ -4,5 +4,5 @@ import fs from 'fs/promises';
 
 export default async function loadPalguardTemplate(to: string) {
   const from = path.join(TEMPLATE_PATH, 'Palguard');
-  fs.cp(from, to, { force: true, recursive: true });
+  await fs.cp(from, to, { force: true, recursive: true });
 }

--- a/src/main/services/templates/loadUE4SSTemplate.ts
+++ b/src/main/services/templates/loadUE4SSTemplate.ts
@@ -4,5 +4,5 @@ import fs from 'fs/promises';
 
 export default async function loadUE4SSTemplate(to: string) {
   const from = path.join(TEMPLATE_PATH, 'UE4SS');
-  fs.cp(from, to, { force: true, recursive: true });
+  await fs.cp(from, to, { force: true, recursive: true });
 }


### PR DESCRIPTION
### Motivation
- Make the plugin-update workflow more robust and authorized when calling GitHub API.  
- Ensure template file copies complete before server startup to avoid race conditions.  
- Add explicit Palguard template support and normalize package engine metadata.

### Description
- Updated `.github/workflows/check-plugin-updates.yml` to add `permissions`, `concurrency`, use `GH_TOKEN` for authenticated GitHub API requests, and added stronger error handling when parsing release data.  
- Added `engines` section in `package.json` (replacing the removed `devEngines`) to declare Node/NPM requirements.  
- Added `src/main/services/templates/loadPalguardTemplate.ts` and updated `src/main/ipcs/server/exec/execStartServer.tsx` to import and `await` the Palguard template copy, and changed the UE4SS template load call to `await`.  
- Updated `loadUE4SSTemplate.ts` and `loadPalguardTemplate.ts` to `await fs.cp(...)` so file operations complete before proceeding.

### Testing
- Ran the project build with `npm run build` which completed successfully.  
- Executed the test suite with `npm test` and lint with `npm run lint`, both of which passed locally.  
- Verified that the updated workflow step will use `GH_TOKEN` and fail fast when release parsing fails during local simulation of the API call.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a696a643a08327b041275692864aca)